### PR TITLE
Hotfix - call to abstract method

### DIFF
--- a/lib/src/widgets/sliver_sticky_header.dart
+++ b/lib/src/widgets/sliver_sticky_header.dart
@@ -287,7 +287,6 @@ class SliverStickyHeaderRenderObjectElement extends RenderObjectElement {
   void forgetChild(Element child) {
     if (child == _header) _header = null;
     if (child == _sliver) _sliver = null;
-    super.forgetChild(child);
   }
 
   @override

--- a/lib/src/widgets/sticky_header_layout_builder.dart
+++ b/lib/src/widgets/sticky_header_layout_builder.dart
@@ -56,7 +56,6 @@ class _StickyHeaderLayoutBuilderElement extends RenderObjectElement {
   void forgetChild(Element child) {
     assert(child == _child);
     _child = null;
-    super.forgetChild(child);
   }
 
   @override


### PR DESCRIPTION
Remove the call to the abstract method forgetChild