### PR TITLE
Fixed _CastError

### DIFF
--- a/lib/src/rendering/sliver_sticky_header.dart
+++ b/lib/src/rendering/sliver_sticky_header.dart
@@ -271,7 +271,7 @@ class RenderSliverStickyHeader extends RenderSliver with RenderSliverHelpers {
         if (_oldState != state) {
           _oldState = state;
           header!.layout(
-            BoxValueConstraints<SliverStickyHeaderState?>(
+            BoxValueConstraints<SliverStickyHeaderState>(
               value: _oldState,
               constraints: constraints.asBoxConstraints(),
             ),


### PR DESCRIPTION
This will fix this error: `type 'BoxValueConstraints<SliverStickyHeaderState?>' is not a subtype of type 'BoxValueConstraints<SliverStickyHeaderState>' in type cast`