### PR TITLE
Fixing SliverStickyHeaderState cast error due to null-safety migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1
+### Fixed
+* Error due to null-safety migration.
+
 ## 0.6.0
 ### Changed
 * Migrated to sound null-safety.

--- a/lib/src/rendering/sliver_sticky_header.dart
+++ b/lib/src/rendering/sliver_sticky_header.dart
@@ -271,8 +271,8 @@ class RenderSliverStickyHeader extends RenderSliver with RenderSliverHelpers {
         if (_oldState != state) {
           _oldState = state;
           header!.layout(
-            BoxValueConstraints<SliverStickyHeaderState?>(
-              value: _oldState,
+            BoxValueConstraints<SliverStickyHeaderState>(
+              value: _oldState!,
               constraints: constraints.asBoxConstraints(),
             ),
             parentUsesSize: true,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_sticky_header
 description: Flutter implementation of sticky headers as a sliver. Use it in a CustomScrollView.
-version: 0.6.0
+version: 0.6.1
 homepage: https://github.com/letsar/flutter_sticky_header
 
 dependencies:


### PR DESCRIPTION
Solves #62 

@letsar please review, thanks!