### PR TITLE
Constructor default values assignment

### DIFF
--- a/lib/src/widgets/sliver_sticky_header.dart
+++ b/lib/src/widgets/sliver_sticky_header.dart
@@ -152,7 +152,7 @@ class SliverStickyHeader extends RenderObjectWidget {
     Key? key,
     this.header,
     this.sliver,
-    this.overlapsContent: false,
+    this.overlapsContent = false,
     this.sticky = true,
     this.controller,
   }) : super(key: key);
@@ -168,7 +168,7 @@ class SliverStickyHeader extends RenderObjectWidget {
     Key? key,
     required SliverStickyHeaderWidgetBuilder builder,
     Widget? sliver,
-    bool overlapsContent: false,
+    bool overlapsContent = false,
     bool sticky = true,
     StickyHeaderController? controller,
   }) : this(
@@ -247,7 +247,7 @@ class SliverStickyHeaderBuilder extends StatelessWidget {
     Key? key,
     required this.builder,
     this.sliver,
-    this.overlapsContent: false,
+    this.overlapsContent = false,
     this.sticky = true,
     this.controller,
   }) : super(key: key);


### PR DESCRIPTION
Default values in constructors are to be assigned with `=` instead of old-style `:`.