### PR TITLE
Fix the tap offset when overlaps is > 0

### DIFF
--- a/lib/src/rendering/sliver_sticky_header.dart
+++ b/lib/src/rendering/sliver_sticky_header.dart
@@ -318,7 +318,7 @@ class RenderSliverStickyHeader extends RenderSliver with RenderSliverHelpers {
       final didHitHeader = hitTestBoxChild(
         BoxHitTestResult.wrap(SliverHitTestResult.wrap(result)),
         header!,
-        mainAxisPosition: mainAxisPosition - childMainAxisPosition(header),
+        mainAxisPosition: mainAxisPosition - childMainAxisPosition(header) - headerPosition,
         crossAxisPosition: crossAxisPosition,
       );
 


### PR DESCRIPTION
Fixes https://github.com/letsar/flutter_sticky_header/issues/80

Issue:
![Issue](https://user-images.githubusercontent.com/970228/196347785-5b535acb-28d2-4c07-b539-bdde1997c196.gif)

Fix:
![Fix](https://user-images.githubusercontent.com/970228/196347797-e3c085ab-237f-482b-b6a5-ed9b15c98172.gif)

@letsar let me know if you have any comments about this, I'm open to spend time solving them.

I'm currently needing this to finish a functionality, so having this packed in a future ^0.6.5 (or sth like that) would be awesome!