### PR TITLE
Add a callback that handles the changes in the state of a sticky header such as "onPinned"

### DIFF
--- a/example/lib/examples/activity_handler.dart
+++ b/example/lib/examples/activity_handler.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_sticky_header/flutter_sticky_header.dart';
+
+import '../common.dart';
+
+class ActivityHandlerExample extends StatefulWidget {
+  const ActivityHandlerExample({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  State<ActivityHandlerExample> createState() => _ActivityHandlerExampleState();
+}
+
+class _ActivityHandlerExampleState extends State<ActivityHandlerExample> {
+  int pinnedHeaderIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return AppScaffold(
+      reverse: false,
+      title: 'Header #$pinnedHeaderIndex is pinned',
+      slivers: [
+        _StickyHeaderList(index: 0, onHeaderPinned: onHeaderPinned),
+        _StickyHeaderList(index: 1, onHeaderPinned: onHeaderPinned),
+        _StickyHeaderList(index: 2, onHeaderPinned: onHeaderPinned),
+        _StickyHeaderList(index: 3, onHeaderPinned: onHeaderPinned),
+      ],
+    );
+  }
+
+  void onHeaderPinned(int index) {
+    setState(() {
+      pinnedHeaderIndex = index;
+    });
+  }
+}
+
+class _StickyHeaderList extends StatelessWidget {
+  const _StickyHeaderList({
+    Key? key,
+    this.index,
+    required this.onHeaderPinned,
+  }) : super(key: key);
+
+  final int? index;
+  final void Function(int index) onHeaderPinned;
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverStickyHeader(
+      activityHandler: (activity) {
+        debugPrint("[Header#$index] $activity");
+        if (activity == SliverStickyHeaderActivity.pinned) {
+          onHeaderPinned(index!);
+        }
+      },
+      header: Header(index: index),
+      sliver: SliverList(
+        delegate: SliverChildBuilderDelegate(
+          (context, i) => ListTile(
+            leading: CircleAvatar(
+              child: Text('$index'),
+            ),
+            title: Text('List tile #$i'),
+          ),
+          childCount: 6,
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:example/examples/activity_handler.dart';
 import 'package:example/examples/nested.dart';
 import 'package:flutter/material.dart';
 
@@ -64,6 +65,10 @@ class _Home extends StatelessWidget {
           _Item(
             text: 'Reverse List Example',
             builder: (_) => const ReverseExample(),
+          ),
+          _Item(
+            text: 'Activity Header Example',
+            builder: (_) => const ActivityHandlerExample(),
           ),
           _Item(
             text: 'Mixing other slivers',

--- a/lib/src/rendering/sliver_sticky_header.dart
+++ b/lib/src/rendering/sliver_sticky_header.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter_sticky_header/flutter_sticky_header.dart';
 import 'package:value_layout_builder/value_layout_builder.dart';
 
@@ -16,12 +17,16 @@ class RenderSliverStickyHeader extends RenderSliver with RenderSliverHelpers {
     bool overlapsContent: false,
     bool sticky: true,
     StickyHeaderController? controller,
+    this.activityHandler,
   })  : _overlapsContent = overlapsContent,
         _sticky = sticky,
         _controller = controller {
     this.header = header as RenderBox?;
     this.child = child;
   }
+
+  SliverStickyHeaderActivityHandler? activityHandler;
+  SliverStickyHeaderActivity? _lastReportedActivity;
 
   SliverStickyHeaderState? _oldState;
   double? _headerExtent;
@@ -261,6 +266,9 @@ class RenderSliverStickyHeader extends RenderSliver with RenderSliverHelpers {
         controller?.stickyHeaderScrollOffset =
             constraints.precedingScrollExtent;
       }
+
+      _tryNotifyActivity(headerScrollRatio);
+
       // second layout if scroll percentage changed and header is a
       // RenderStickyHeaderLayoutBuilder.
       if (header is RenderConstrainedLayoutBuilder<
@@ -298,6 +306,32 @@ class RenderSliverStickyHeader extends RenderSliver with RenderSliverHelpers {
           break;
       }
     }
+  }
+
+  void _tryNotifyActivity(double headerScrollRatio) {
+    final SliverStickyHeaderActivity location;
+    if (_isPinned) {
+      if (headerScrollRatio >= 1) {
+        location = SliverStickyHeaderActivity.pushed;
+      } else if (headerScrollRatio > 0) {
+        location = SliverStickyHeaderActivity.settling;
+      } else {
+        location = SliverStickyHeaderActivity.pinned;
+      }
+    } else {
+      location = SliverStickyHeaderActivity.unpinned;
+    }
+
+    if (activityHandler != null &&
+        _lastReportedActivity != null &&
+        location != _lastReportedActivity) {
+      WidgetsBinding.instance.scheduleTask(
+        () => activityHandler?.call(location),
+        Priority.touch,
+      );
+    }
+
+    _lastReportedActivity = location;
   }
 
   @override

--- a/lib/src/rendering/sliver_sticky_header.dart
+++ b/lib/src/rendering/sliver_sticky_header.dart
@@ -309,29 +309,29 @@ class RenderSliverStickyHeader extends RenderSliver with RenderSliverHelpers {
   }
 
   void _tryNotifyActivity(double headerScrollRatio) {
-    final SliverStickyHeaderActivity location;
+    final SliverStickyHeaderActivity activity;
     if (_isPinned) {
       if (headerScrollRatio >= 1) {
-        location = SliverStickyHeaderActivity.pushed;
+        activity = SliverStickyHeaderActivity.pushed;
       } else if (headerScrollRatio > 0) {
-        location = SliverStickyHeaderActivity.settling;
+        activity = SliverStickyHeaderActivity.settling;
       } else {
-        location = SliverStickyHeaderActivity.pinned;
+        activity = SliverStickyHeaderActivity.pinned;
       }
     } else {
-      location = SliverStickyHeaderActivity.unpinned;
+      activity = SliverStickyHeaderActivity.unpinned;
     }
 
     if (activityHandler != null &&
         _lastReportedActivity != null &&
-        location != _lastReportedActivity) {
+        activity != _lastReportedActivity) {
       WidgetsBinding.instance.scheduleTask(
-        () => activityHandler?.call(location),
+        () => activityHandler?.call(activity),
         Priority.touch,
       );
     }
 
-    _lastReportedActivity = location;
+    _lastReportedActivity = activity;
   }
 
   @override

--- a/lib/src/widgets/sliver_sticky_header.dart
+++ b/lib/src/widgets/sliver_sticky_header.dart
@@ -134,6 +134,13 @@ class SliverStickyHeaderState {
   }
 }
 
+enum SliverStickyHeaderLocation {
+  pushed,
+  notPinned,
+  pinned,
+  settling,
+}
+
 /// A sliver that displays a header before its sliver.
 /// The header scrolls off the viewport only when the sliver does.
 ///

--- a/lib/src/widgets/sliver_sticky_header.dart
+++ b/lib/src/widgets/sliver_sticky_header.dart
@@ -134,13 +134,23 @@ class SliverStickyHeaderState {
   }
 }
 
+/// A callback that handles a [SliverStickyHeaderActivity].
 typedef SliverStickyHeaderActivityHandler = void Function(
     SliverStickyHeaderActivity activity);
 
+/// An event that is dispatched when a sticky header changes its position meaningfully.
 enum SliverStickyHeaderActivity {
+  /// Dispatched when the sticky header is completely pushed
+  /// out of the viewport by the subsequent header.
   pushed,
+
+  /// Dispatched when the sticky header is unpinned.
   unpinned,
+
+  /// Dispatched when the sticky header begin to be pinned.
   pinned,
+
+  /// Dispatched when the sticky header begins to be pushed by the subsequent header.
   settling,
 }
 
@@ -216,6 +226,7 @@ class SliverStickyHeader extends RenderObjectWidget {
   /// will be used.
   final StickyHeaderController? controller;
 
+  /// A callback invoked when a [SliverStickyHeaderActivity] is dispatched.
   final SliverStickyHeaderActivityHandler? activityHandler;
 
   @override

--- a/lib/src/widgets/sliver_sticky_header.dart
+++ b/lib/src/widgets/sliver_sticky_header.dart
@@ -134,6 +134,9 @@ class SliverStickyHeaderState {
   }
 }
 
+typedef SliverStickyHeaderActivityHandler = void Function(
+    SliverStickyHeaderActivity activity);
+
 enum SliverStickyHeaderActivity {
   pushed,
   unpinned,
@@ -162,6 +165,7 @@ class SliverStickyHeader extends RenderObjectWidget {
     this.overlapsContent: false,
     this.sticky = true,
     this.controller,
+    this.activityHandler,
   }) : super(key: key);
 
   /// Creates a widget that builds the header of a [SliverStickyHeader]
@@ -178,6 +182,7 @@ class SliverStickyHeader extends RenderObjectWidget {
     bool overlapsContent: false,
     bool sticky = true,
     StickyHeaderController? controller,
+    SliverStickyHeaderActivityHandler? activityHandler,
   }) : this(
           key: key,
           header: ValueLayoutBuilder<SliverStickyHeaderState>(
@@ -188,6 +193,7 @@ class SliverStickyHeader extends RenderObjectWidget {
           overlapsContent: overlapsContent,
           sticky: sticky,
           controller: controller,
+          activityHandler: activityHandler,
         );
 
   /// The header to display before the sliver.
@@ -210,12 +216,15 @@ class SliverStickyHeader extends RenderObjectWidget {
   /// will be used.
   final StickyHeaderController? controller;
 
+  final SliverStickyHeaderActivityHandler? activityHandler;
+
   @override
   RenderSliverStickyHeader createRenderObject(BuildContext context) {
     return RenderSliverStickyHeader(
       overlapsContent: overlapsContent,
       sticky: sticky,
       controller: controller ?? DefaultStickyHeaderController.of(context),
+      activityHandler: activityHandler,
     );
   }
 
@@ -231,7 +240,8 @@ class SliverStickyHeader extends RenderObjectWidget {
     renderObject
       ..overlapsContent = overlapsContent
       ..sticky = sticky
-      ..controller = controller ?? DefaultStickyHeaderController.of(context);
+      ..controller = controller ?? DefaultStickyHeaderController.of(context)
+      ..activityHandler = activityHandler;
   }
 }
 

--- a/lib/src/widgets/sliver_sticky_header.dart
+++ b/lib/src/widgets/sliver_sticky_header.dart
@@ -134,9 +134,9 @@ class SliverStickyHeaderState {
   }
 }
 
-enum SliverStickyHeaderLocation {
+enum SliverStickyHeaderActivity {
   pushed,
-  notPinned,
+  unpinned,
   pinned,
   settling,
 }


### PR DESCRIPTION
This PR fixes #48 by adding a callback to be called when a sticky header is pinned or unpinned, etc. It also works with reversed scrollable widgets.

- Added `SliverStickyHeaderActivity` class that represents an event such as "onPinned"
- Added callback parameters to the constructors of `SliverStickyHeader`
- Added a new example to `example/lib/main.dart`

I hope you find it useful 😀